### PR TITLE
Center and center menu container

### DIFF
--- a/app/components/chat/MCPTools.tsx
+++ b/app/components/chat/MCPTools.tsx
@@ -64,7 +64,7 @@ export function McpTools() {
 
       <DialogRoot open={isDialogOpen} onOpenChange={handleDialogOpen}>
         {isDialogOpen && (
-          <Dialog className="max-w-4xl w-full p-6">
+          <Dialog className="max-w-4xl w-full">
             <div className="space-y-4 max-h-[80vh] overflow-y-auto pr-2">
               <DialogTitle>
                 <div className="i-bolt:mcp text-xl"></div>

--- a/app/components/chat/SupabaseConnection.tsx
+++ b/app/components/chat/SupabaseConnection.tsx
@@ -99,7 +99,7 @@ export function SupabaseConnection() {
 
       <DialogRoot open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         {isDialogOpen && (
-          <Dialog className="max-w-[520px] p-6">
+          <Dialog className="max-w-[520px]">
             {!isConnected ? (
               <div className="space-y-4">
                 <DialogTitle>

--- a/app/components/ui/ColorSchemeDialog.tsx
+++ b/app/components/ui/ColorSchemeDialog.tsx
@@ -278,7 +278,7 @@ export const ColorSchemeDialog: React.FC<ColorSchemeDialogProps> = ({ setDesignS
 
       <DialogRoot open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <Dialog>
-          <div className="py-4 px-4 min-w-[480px] max-w-[90vw] max-h-[85vh] flex flex-col gap-6 overflow-hidden">
+          <div className="py-4 px-4 min-w-[480px] max-w-[90vw] max-h-[85vh] flex flex-col gap-6 overflow-hidden touch-manipulation">
             <div className="">
               <DialogTitle className="text-2xl font-bold text-bolt-elements-textPrimary">
                 Design Palette & Features

--- a/app/components/ui/Dialog.tsx
+++ b/app/components/ui/Dialog.tsx
@@ -22,7 +22,7 @@ export const DialogButton = memo(({ type, children, onClick, disabled }: DialogB
   return (
     <button
       className={classNames(
-        'inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm transition-colors',
+        'inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm transition-colors min-h-[44px] touch-manipulation',
         type === 'primary'
           ? 'bg-purple-500 text-white hover:bg-purple-600 dark:bg-purple-500 dark:hover:bg-purple-600'
           : type === 'secondary'
@@ -78,7 +78,7 @@ export const dialogBackdropVariants = {
 export const dialogVariants = {
   closed: {
     x: '-50%',
-    y: '-40%',
+    y: '-50%',
     scale: 0.96,
     opacity: 0,
     transition,
@@ -101,6 +101,16 @@ interface DialogProps {
 }
 
 export const Dialog = memo(({ children, className, showCloseButton = true, onClose, onBackdrop }: DialogProps) => {
+  // Prevent background scrolling when modal is open
+  useEffect(() => {
+    const originalStyle = window.getComputedStyle(document.body).overflow;
+    document.body.style.overflow = 'hidden';
+    
+    return () => {
+      document.body.style.overflow = originalStyle;
+    };
+  }, []);
+
   return (
     <RadixDialog.Portal>
       <RadixDialog.Overlay asChild>
@@ -116,7 +126,10 @@ export const Dialog = memo(({ children, className, showCloseButton = true, onClo
       <RadixDialog.Content asChild>
         <motion.div
           className={classNames(
-            'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-950 rounded-lg shadow-xl border border-bolt-elements-borderColor z-[9999] w-[520px] focus:outline-none',
+            'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-950 rounded-lg shadow-xl border border-bolt-elements-borderColor z-[9999] w-[520px] max-w-[90vw] max-h-[90vh] overflow-y-auto focus:outline-none touch-action-manipulation',
+            'flex flex-col justify-center items-center',
+            'sm:w-[520px] sm:max-w-[90vw]',
+            'max-sm:w-[95vw] max-sm:max-h-[90vh] max-sm:mx-4',
             className,
           )}
           initial="closed"
@@ -124,13 +137,13 @@ export const Dialog = memo(({ children, className, showCloseButton = true, onClo
           exit="closed"
           variants={dialogVariants}
         >
-          <div className="flex flex-col">
+          <div className="flex flex-col w-full h-full min-h-0 p-4">
             {children}
             {showCloseButton && (
               <RadixDialog.Close asChild onClick={onClose}>
                 <IconButton
                   icon="i-ph:x"
-                  className="absolute top-3 right-3 text-bolt-elements-textTertiary hover:text-bolt-elements-textSecondary"
+                  className="absolute top-3 right-3 text-bolt-elements-textTertiary hover:text-bolt-elements-textSecondary min-h-[44px] min-w-[44px] touch-manipulation"
                 />
               </RadixDialog.Close>
             )}


### PR DESCRIPTION
Center all modals on the screen, ensure responsiveness, and improve touch support.

The previous modal implementation was not consistently centered or responsive, leading to a suboptimal user experience on various screen sizes and touch devices. This PR addresses these issues by applying modern CSS techniques (flexbox, fixed positioning, media queries) and touch-friendly attributes to the core `Dialog` component and its consumers.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bd1f193-fa6f-4d57-a6d9-1085e922331e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3bd1f193-fa6f-4d57-a6d9-1085e922331e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Centered all dialogs and standardized sizing and touch targets across the app. Modals are now responsive on small screens and the page won’t scroll in the background.

- **New Features**
  - Locks body scroll while a dialog is open.
  - Standardized responsive sizing: max-w 90vw, max-h 90vh, overflow-y auto.
  - Improved touch support: min 44px button/close sizes and touch-manipulation attributes.
  - Exact vertical centering via y: -50% in dialog animation.
  - Simplified consumers: removed extra padding in MCPTools and SupabaseConnection; added touch-manipulation in ColorSchemeDialog.

<!-- End of auto-generated description by cubic. -->

